### PR TITLE
Allow configurable host address

### DIFF
--- a/appserver/src/appserver.py
+++ b/appserver/src/appserver.py
@@ -390,7 +390,7 @@ def main():
     app.route(app.config['URL'] + "/worker-api", methods=['POST'])(mtmonkey.worker_api)
 
     # run
-    app.run(host="", port=app.config['PORT'], threaded=True)
+    app.run(host=app.config.get('HOST'), port=app.config['PORT'], threaded=True)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
To support port forwarding from Docker, Flask server needs to run on an address different from 127.0.0.1 (see [blog-post](https://synchronizing.medium.com/running-a-simple-flask-application-inside-a-docker-container-b83bf3e07dd5))
This change enables the user to specify host address used by Flask. By default empty value would still go t o127.0.0.1